### PR TITLE
fix error before noon when am/pm is enabled

### DIFF
--- a/clockwidget.py
+++ b/clockwidget.py
@@ -311,7 +311,7 @@ class ClockWidget(QtWidgets.QWidget):
         digitSpacingY = 45
         secondsOffsetX = -3.5
 
-        if self.isAmPm:
+        if self.isAmPm and time.hour() > 12:
             hourStr = "%02d" % (time.hour()-12)
         else:
             hourStr = "%02d" % time.hour()


### PR DESCRIPTION
always subtracting 12 from the current hour can result in negative values, which then creates a python error and crashes the application.