### PR TITLE
Fixes problems with API call when WeatherWidget is disabled.

### DIFF
--- a/start.py
+++ b/start.py
@@ -682,7 +682,6 @@ class MainScreen(QWidget, Ui_MainScreen):
 
         settings.beginGroup("WeatherWidget")
         if settings.value('owmWidgetEnabled', False, type=bool):
-            pass
             self.weatherWidget.show()
         else:
             self.weatherWidget.hide()

--- a/weatherwidget.py
+++ b/weatherwidget.py
@@ -168,7 +168,8 @@ class WeatherWidget(QtWidgets.QWidget):
 
     def updateWeather(self):
         print("update weather called")
-        self.makeOWMApiCall()
+        if self.widgetEnabled:
+            self.makeOWMApiCall()
 
     def setData(self, city, temperature, condition, icon="01d", background=None, label="WEATHER"):
         print("Weather:", icon, background)

--- a/weatherwidget.py
+++ b/weatherwidget.py
@@ -167,8 +167,8 @@ class WeatherWidget(QtWidgets.QWidget):
         self.updateTimer.start(10 * 60 * 1000)
 
     def updateWeather(self):
-        print("update weather called")
         if self.widgetEnabled:
+            print("update weather called")
             self.makeOWMApiCall()
 
     def setData(self, city, temperature, condition, icon="01d", background=None, label="WEATHER"):


### PR DESCRIPTION
Even though the config file has the widget disabled, the call is made when 'updateWeather' is called. If the config file does not have an API key filled in, this results in an error. By adding a check to 'updateWeather', this fixes the issue.