### PR TITLE
Add cmdtest scripts for HTTP and UDP testing

### DIFF
--- a/utils/cmdtest_http.sh
+++ b/utils/cmdtest_http.sh
@@ -34,12 +34,73 @@ sleep 1
 curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=LED4:OFF"
 sleep 1
 
+# Test AIR Timer Commands
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR1:ON"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR1:OFF"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR2:ON"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR2:OFF"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR3:ON"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR3:OFF"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR3:RESET"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR3:TOGGLE"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR3TIME:120"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR4:ON"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR4:OFF"
+sleep 1
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=AIR4:RESET"
+sleep 1
+
+# Test General Configuration
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:General:stationname=Test Radio Station"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:General:slogan=Your Music, Your Way"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:General:stationcolor=#FF0000"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:General:slogancolor=#00FF00"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:CONF:APPLY=TRUE"
+sleep 1
+
+# Test LED Configuration
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:LED1:text=ON AIR"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:LED2:text=ATTENTION"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:LED3:text=DOORBELL"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:LED4:text=PHONE"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:LED1:used=True"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:LED1:activebgcolor=#FF0000"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:LED1:activetextcolor=#FFFFFF"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:LED1:autoflash=True"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:LED1:timedflash=False"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:CONF:APPLY=TRUE"
+sleep 1
+
+# Test Clock Configuration
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:Clock:digital=True"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:Clock:digitalhourcolor=#FFFFFF"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:Clock:digitalsecondcolor=#FFFF00"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:Clock:digitaldigitcolor=#00FFFF"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:CONF:APPLY=TRUE"
+sleep 1
+
+# Test Timer Configuration
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:Timers:TimerAIR1Enabled=True"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:Timers:TimerAIR1Text=Mic"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:Timers:TimerAIR2Text=Phone"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:Timers:TimerAIR3Text=Radio"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:Timers:TimerAIR4Text=Stream"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:CONF:APPLY=TRUE"
+sleep 1
+
+# Test Network Configuration
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:Network:udpport=3310"
+curl "http://127.0.0.1:8010/" --get --data-urlencode "cmd=CONF:CONF:APPLY=TRUE"
+sleep 1
 
 exit
-echo -e "LED1:ON\nLED2:ON\nLED3:ON\nLED4:ON"
-conf="LED1TEXT=ON AIR\n
-LED2TEXT=ATTENTION\n
-LED3TEXT=DOORBELL\n
-LED4TEXT=PHONE\n
-"
-echo -e "CONF:$conf"

--- a/utils/cmdtest_udp.sh
+++ b/utils/cmdtest_udp.sh
@@ -1,25 +1,37 @@
 #!/bin/bash
 
+echo "========================================="
+echo "OnAirScreen UDP Command Test Script"
+echo "========================================="
+echo ""
+
+echo "[TEST] Clock Configuration - showseconds"
 echo  "CONF:Clock:showseconds=True" | nc -w 1 -u 127.0.0.1 3310
 echo  "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
 echo  "CONF:Clock:showseconds=False" | nc -w 1 -u 127.0.0.1 3310
 echo  "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
+
+echo "[TEST] Clock Configuration - secondsinoneline"
 echo  "CONF:Clock:secondsinoneline=True" | nc -w 1 -u 127.0.0.1 3310
 echo  "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
 echo  "CONF:Clock:secondsinoneline=False" | nc -w 1 -u 127.0.0.1 3310
 echo  "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
 
+echo "[TEST] Clock Configuration - logoupper"
 echo  "CONF:Clock:logoupper=True" | nc -w 1 -u 127.0.0.1 3310
 echo  "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
 echo  "CONF:Clock:logoupper=False" | nc -w 1 -u 127.0.0.1 3310
 echo  "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
 
+echo "[TEST] NOW/NEXT Text Commands"
 echo  "NOW:The Testers - Test around the clock" | nc -w 1 -u 127.0.0.1 3310
 echo  "NEXT:coming up next: the foo the bar and the generic" | nc -w 1 -u 127.0.0.1 3310
 
+echo "[TEST] WARN Command"
 echo  "WARN:The system is testing..." | nc -w 1 -u 127.0.0.1 3310
 echo  "WARN:" | nc -w 1 -u 127.0.0.1 3310
 
+echo "[TEST] LED Commands - Individual LEDs"
 echo "LED1:ON" | nc -w 1 -u 127.0.0.1 3310
 echo "LED1:OFF" | nc -w 1 -u 127.0.0.1 3310
 echo "LED2:ON" | nc -w 1 -u 127.0.0.1 3310
@@ -29,18 +41,87 @@ echo "LED3:OFF" | nc -w 1 -u 127.0.0.1 3310
 echo "LED4:ON" | nc -w 1 -u 127.0.0.1 3310
 echo "LED4:OFF" | nc -w 1 -u 127.0.0.1 3310
 
-
+echo "[TEST] LED Commands - Multiple LEDs in one packet"
 echo -e "LED1:ON\nLED2:ON\nLED3:ON\nLED4:ON" | nc -w 1 -u 127.0.0.1 3310
 echo -e "LED1:OFF\nLED2:OFF\nLED3:OFF\nLED4:OFF" | nc -w 1 -u 127.0.0.1 3310
 
+echo "[TEST] AIR Timer Commands"
+echo "  -> AIR1:ON/OFF"
+echo "AIR1:ON" | nc -w 1 -u 127.0.0.1 3310
+echo "AIR1:OFF" | nc -w 1 -u 127.0.0.1 3310
+echo "  -> AIR2:ON/OFF"
+echo "AIR2:ON" | nc -w 1 -u 127.0.0.1 3310
+echo "AIR2:OFF" | nc -w 1 -u 127.0.0.1 3310
+echo "  -> AIR3:ON/OFF/RESET/TOGGLE"
+echo "AIR3:ON" | nc -w 1 -u 127.0.0.1 3310
+echo "AIR3:OFF" | nc -w 1 -u 127.0.0.1 3310
+echo "AIR3:RESET" | nc -w 1 -u 127.0.0.1 3310
+echo "AIR3:TOGGLE" | nc -w 1 -u 127.0.0.1 3310
+echo "  -> AIR3TIME:120"
+echo "AIR3TIME:120" | nc -w 1 -u 127.0.0.1 3310
+echo "  -> AIR4:ON/OFF/RESET"
+echo "AIR4:ON" | nc -w 1 -u 127.0.0.1 3310
+echo "AIR4:OFF" | nc -w 1 -u 127.0.0.1 3310
+echo "AIR4:RESET" | nc -w 1 -u 127.0.0.1 3310
 
+echo "[TEST] General Configuration"
+echo "  -> Station Name, Slogan, Colors"
+echo "CONF:General:stationname=Test Radio Station" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:General:slogan=Your Music, Your Way" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:General:stationcolor=#FF0000" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:General:slogancolor=#00FF00" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
 
-exit
+echo "[TEST] LED Configuration"
+echo "  -> LED Text, Colors, Flash Settings"
+echo "CONF:LED1:text=ON AIR" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:LED2:text=ATTENTION" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:LED3:text=DOORBELL" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:LED4:text=PHONE" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:LED1:used=True" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:LED1:activebgcolor=#FF0000" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:LED1:activetextcolor=#FFFFFF" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:LED1:autoflash=True" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:LED1:timedflash=False" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
 
+echo "[TEST] Clock Configuration"
+echo "  -> Digital Mode, Colors"
+echo "CONF:Clock:digital=True" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:Clock:digitalhourcolor=#FFFFFF" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:Clock:digitalsecondcolor=#FFFF00" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:Clock:digitaldigitcolor=#00FFFF" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
 
+echo "[TEST] Timer Configuration"
+echo "  -> Timer Enabled, Timer Text"
+echo "CONF:Timers:TimerAIR1Enabled=True" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:Timers:TimerAIR1Text=Mic" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:Timers:TimerAIR2Text=Phone" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:Timers:TimerAIR3Text=Radio" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:Timers:TimerAIR4Text=Stream" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
+
+echo "[TEST] Network Configuration"
+echo "  -> UDP Port"
+echo "CONF:Network:udpport=3310" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
+
+echo "[TEST] Multiple Commands in One Packet"
+echo "  -> NOW, NEXT, LED1, LED2"
+echo -e "NOW:Current Song Title\nNEXT:Next Song Title\nLED1:ON\nLED2:ON" | nc -w 1 -u 127.0.0.1 3310
+
+echo "[TEST] LED Text Configuration - Multi-line Format"
 conf="LED1TEXT=ON AIR\n
 LED2TEXT=ATTENTION\n
 LED3TEXT=DOORBELL\n
 LED4TEXT=PHONE\n
 "
 echo -e "CONF:$conf" | nc -w 1 -u 127.0.0.1 3310
+echo "CONF:CONF:APPLY=TRUE" | nc -w 1 -u 127.0.0.1 3310
+
+echo ""
+echo "========================================="
+echo "Test completed!"
+echo "========================================="
+exit


### PR DESCRIPTION
This PR adds improved command testing scripts for HTTP and UDP protocols.

## Changes

- **cmdtest_http.sh**: Script for testing HTTP-based commands
- **cmdtest_udp.sh**: Script for testing UDP-based commands

These scripts help with testing and debugging OnAirScreen command functionality.