### PR TITLE
Update paho-mqtt to >=2.1.0 with CallbackAPIVersion fix

### DIFF
--- a/mqtt_client.py
+++ b/mqtt_client.py
@@ -144,8 +144,9 @@ class MqttClient(QThread):
         self._load_config()
         
         try:
-            # Create MQTT client
+            # Create MQTT client (explicit VERSION1 avoids DeprecationWarning on paho-mqtt 2.x)
             self.client = mqtt.Client(
+                mqtt.CallbackAPIVersion.VERSION1,
                 client_id=self.client_id,
                 protocol=mqtt.MQTTv311
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ PyInstaller
 pytest
 pytest-asyncio
 websockets>=16.1.1
-paho-mqtt>=1.6.0
+paho-mqtt>=2.1.0


### PR DESCRIPTION
## Summary
- Raise `paho-mqtt` requirement from `>=1.6.0` to `>=2.1.0` (supersedes Dependabot #64, which conflicted after #66)
- Pass `mqtt.CallbackAPIVersion.VERSION1` explicitly when creating the MQTT client to avoid DeprecationWarning and stay compatible with paho-mqtt 2.x

## Test plan
- [x] `pytest tests/test_mqtt_client.py` (44 passed)
- [ ] Manual MQTT connect / Home Assistant autodiscovery smoke test if available